### PR TITLE
chore: add CI workflow and contribution guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ "work" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Format
+        run: pre-commit run --all-files
+      - name: Analyze
+        run: flutter analyze
+      - name: Test
+        run: dart test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: dart-format
+        name: dart format
+        entry: dart format --output=none --set-exit-if-changed
+        language: system
+        types: [dart]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Thank you for taking the time to contribute!
+
+## Workflow
+
+1. Install the latest versions of [Flutter](https://flutter.dev) and Dart.
+2. Fetch dependencies:
+   ```bash
+   flutter pub get
+   ```
+3. Format and lint the code:
+   ```bash
+   pre-commit run --all-files
+   flutter analyze
+   ```
+4. Run the tests:
+   ```bash
+   dart test
+   ```
+
+The continuous integration workflow runs the same steps for every pull request.


### PR DESCRIPTION
## Summary
- run Dart format, `flutter analyze`, and tests in CI
- add pre-commit configuration for `dart format`
- document contribution workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: Because root requires the Flutter SDK, version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a3681f468832d91cc184136ef4752